### PR TITLE
added service categories to company sign up page

### DIFF
--- a/app/controllers/companies/registrations_controller.rb
+++ b/app/controllers/companies/registrations_controller.rb
@@ -10,10 +10,16 @@ before_action :configure_account_update_params, only: [:update]
 
   # POST /resource
   def create
-    @service_categories = ServiceCategory.all
     super
+    @service_categories = ServiceCategory.all
+    params['service_category'].each do |service_category|
+      CompanyService.create(
+        company_id: current_company.id,
+        service_category_id: service_category.to_i
+      )
+    end
   end
-
+  
   # GET /resource/edit
   def edit
     @service_categories = ServiceCategory.all

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -66,6 +66,16 @@
     <%= f.number_field :service_radius, autofocus: true %>
   </div>
 
+  <div>Service Categories Offered
+    <% @service_categories.each do |service_category| %>
+      <div class="btn-group" data-toggle="buttons">
+        <label class="btn btn-primary"> 
+          <%= check_box_tag 'service_category[]', service_category.id, checked = false %> <%= service_category.name %>
+        </label>
+      </div>
+    <% end %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>


### PR DESCRIPTION
changed devise registration controller's create method to allow service categories to be chosen from company sign up page 

trello: https://trello.com/c/1N7lduNW/42-company-can-add-service-categories-during-sign-up-process