### PR TITLE
Open quote bug

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -34,8 +34,16 @@ class ContractsController < ApplicationController
             if quote.accepted
               CompanyMailer.accept_email(quote).deliver_now
             else
-              CompanyMailer.decline_email(quote).deliver_now
-              quote.update(accepted: false)
+              begin
+                CompanyMailer.decline_email(quote).deliver_now
+              rescue => e
+                Raven.capture_message(
+                  'Failed to send declined quote email.',
+                  extra: { error: e }
+                )
+              ensure
+                quote.update(accepted: false)
+              end
             end
           end
         end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -35,14 +35,15 @@ class ContractsController < ApplicationController
               CompanyMailer.accept_email(quote).deliver_now
             else
               begin
+                quote.update(accepted: false)
                 CompanyMailer.decline_email(quote).deliver_now
               rescue => e
                 Raven.capture_message(
                   'Failed to send declined quote email.',
                   extra: { error: e }
                 )
-              ensure
-                quote.update(accepted: false)
+              # ensure
+                
               end
             end
           end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -35,15 +35,14 @@ class ContractsController < ApplicationController
               CompanyMailer.accept_email(quote).deliver_now
             else
               begin
-                quote.update(accepted: false)
                 CompanyMailer.decline_email(quote).deliver_now
               rescue => e
                 Raven.capture_message(
                   'Failed to send declined quote email.',
                   extra: { error: e }
                 )
-              # ensure
-                
+              ensure
+                quote.update(accepted: false)
               end
             end
           end

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -1,13 +1,9 @@
 class QuotesController < ApplicationController
   def index
     if current_customer
-      # if params[:request_id]
-      #   @customer_requests = CustomerRequest.where('id = ?', params[:request_id]).where('expires_date >= ?', Date.today())
-      # else
-        @customer_requests = current_customer.customer_requests.where(
-          'expires_date >= ?', Date.today()
-        ).select { |cr| cr.contract.nil? }
-      # end
+      @customer_requests = current_customer.customer_requests.where(
+        'expires_date >= ?', Date.today()
+      ).select { |cr| cr.contract.nil? }
       @open_quotes = current_customer.open_quotes
       @accepted_quotes = current_customer.accepted_quotes
     elsif current_company

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -1,9 +1,6 @@
 class QuotesController < ApplicationController
   def index
     if current_customer
-      @customer_requests = current_customer.customer_requests.where(
-        'expires_date >= ?', Date.today()
-      ).select { |cr| cr.contract.nil? }
       @open_quotes = current_customer.open_quotes
       @accepted_quotes = current_customer.accepted_quotes
     elsif current_company

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -1,11 +1,13 @@
 class QuotesController < ApplicationController
   def index
     if current_customer
-      if params[:request_id]
-        @customer_requests = CustomerRequest.where('id = ?', params[:request_id]).where('expires_date >= ?', Date.today())
-      else
-        @customer_requests = current_customer.customer_requests.where('expires_date >= ?', Date.today())
-      end
+      # if params[:request_id]
+      #   @customer_requests = CustomerRequest.where('id = ?', params[:request_id]).where('expires_date >= ?', Date.today())
+      # else
+        @customer_requests = current_customer.customer_requests.where(
+          'expires_date >= ?', Date.today()
+        ).select { |cr| cr.contract.nil? }
+      # end
       @open_quotes = current_customer.open_quotes
       @accepted_quotes = current_customer.accepted_quotes
     elsif current_company

--- a/app/views/quotes/_company_quotes.html.erb
+++ b/app/views/quotes/_company_quotes.html.erb
@@ -2,7 +2,7 @@
   <div class="panel panel-default">
     <div class="panel-body">
     <h2>Open Quotes</h2>
-        <table class="table table-hover table-condensed">
+        <table id="open_quotes" class="table table-hover table-condensed">
           <thead>
             <tr>
               <th>Request Description</th>
@@ -47,7 +47,7 @@
   <div class="panel panel-default">
     <div class="panel-body">
     <h2>Accepted Quotes</h2>
-        <table class="table table-hover table-condensed">
+        <table id="accepted_quotes" class="table table-hover table-condensed">
           <thead>
             <tr>
               <th>Request Description</th>

--- a/app/views/quotes/_company_quotes.html.erb
+++ b/app/views/quotes/_company_quotes.html.erb
@@ -2,7 +2,6 @@
   <div class="panel panel-default">
     <div class="panel-body">
     <h2>Open Quotes</h2>
-      <% @open_quotes.each do |open_quote| %>
         <table class="table table-hover table-condensed">
           <thead>
             <tr>
@@ -16,6 +15,7 @@
             </tr>
           </thead>
           <tbody>
+          <% @open_quotes.each do |open_quote| %>
           <% if open_quote.customer_viewed == false %>
             <tr style="font-weight: bold;">
               <td><%= open_quote.customer_request.description %></td>
@@ -37,9 +37,9 @@
               <td><a href="/quotes/<%= open_quote.id %>"><button class="btn btn-success">Details</button></a></td>
             </tr>
           <% end %>
+          <% end %>
           </tbody>
         </table>
-      <% end %>
     </div>
   </div>
 <% end %>
@@ -47,7 +47,6 @@
   <div class="panel panel-default">
     <div class="panel-body">
     <h2>Accepted Quotes</h2>
-      <% @accepted_quotes.each do |accepted_quote| %>
         <table class="table table-hover table-condensed">
           <thead>
             <tr>
@@ -61,6 +60,7 @@
             </tr>
           </thead>
           <tbody>
+            <% @accepted_quotes.each do |accepted_quote| %>
             <tr>
               <td><%= accepted_quote.customer_request.description %></td>
               <td><%= accepted_quote.customer_request.expires_date %></td>                  
@@ -70,9 +70,9 @@
               <td><%= number_to_currency(accepted_quote.total_cost_estimate) %></td>
               <td><a href="/quotes/<%= accepted_quote.id %>"><button class="btn btn-success">Details</button></a></td>
             </tr>
+            <% end %>
           </tbody>
         </table>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/quotes/_company_quotes.html.erb
+++ b/app/views/quotes/_company_quotes.html.erb
@@ -4,9 +4,10 @@
     <h2>Open Quotes</h2>
       <% @open_quotes.each do |open_quote| %>
         <table class="table table-hover table-condensed">
-        <span><h3><%= open_quote.customer_request.description %></h3><h5>Request Expires: <%= open_quote.customer_request.expires_date %></h5></span> 
           <thead>
             <tr>
+              <th>Request Description</th>
+              <th>Request Expires</th>              
               <th>Company</th>
               <th>Start Date</th>
               <th>Completion Date Estimate</th>
@@ -17,6 +18,8 @@
           <tbody>
           <% if open_quote.customer_viewed == false %>
             <tr style="font-weight: bold;">
+              <td><%= open_quote.customer_request.description %></td>
+              <td><%= open_quote.customer_request.expires_date %></td>
               <td><%= open_quote.company.name%></td>
               <td><%= open_quote.start_date.strftime("%B %e, %Y") %></td>
               <td><%= open_quote.completion_date_estimate.strftime("%B %e, %Y")%></td>
@@ -25,6 +28,8 @@
             </tr>
           <% else %>
             <tr>
+              <td><%= open_quote.customer_request.description %></td>
+              <td><%= open_quote.customer_request.expires_date %></td>              
               <td><%= open_quote.company.name%></td>
               <td><%= open_quote.start_date.strftime("%B %e, %Y") %></td>
               <td><%= open_quote.completion_date_estimate.strftime("%B %e, %Y")%></td>
@@ -44,9 +49,10 @@
     <h2>Accepted Quotes</h2>
       <% @accepted_quotes.each do |accepted_quote| %>
         <table class="table table-hover table-condensed">
-        <span><h3><%= accepted_quote.customer_request.description %></h3><h5>Request Expires: <%= accepted_quote.customer_request.expires_date %></h5></span> 
           <thead>
             <tr>
+              <th>Request Description</th>
+              <th>Request Expires</th>                 
               <th>Company</th>
               <th>Start Date</th>
               <th>Completion Date Estimate</th>
@@ -56,6 +62,8 @@
           </thead>
           <tbody>
             <tr>
+              <td><%= accepted_quote.customer_request.description %></td>
+              <td><%= accepted_quote.customer_request.expires_date %></td>                  
               <td><%= accepted_quote.company.name%></td>
               <td><%= accepted_quote.start_date.strftime("%B %e, %Y") %></td>
               <td><%= accepted_quote.completion_date_estimate.strftime("%B %e, %Y") %></td>

--- a/app/views/quotes/_customer_quotes.html.erb
+++ b/app/views/quotes/_customer_quotes.html.erb
@@ -2,7 +2,7 @@
   <div class="panel panel-default">
     <div class="panel-body">
       <h2>Open Quotes</h2>
-        <table class="table table-hover table-condensed">
+        <table id="open_quotes" class="table table-hover table-condensed">
           <thead>
             <tr>
               <th>Request Description</th>
@@ -35,7 +35,7 @@
   <div class="panel panel-default">
     <div class="panel-body">
     <h2>Accepted Quotes</h2>
-        <table class="table table-hover table-condensed">
+        <table id="accepted_quotes" class="table table-hover table-condensed">
           <thead>
             <tr>
               <th>Request Description</th>

--- a/app/views/quotes/_customer_quotes.html.erb
+++ b/app/views/quotes/_customer_quotes.html.erb
@@ -1,12 +1,13 @@
 <% if @open_quotes %>
   <div class="panel panel-default">
     <div class="panel-body">
-    <h2>Open Quotes</h2>
-      <% @customer_requests.each do |cr| %>
-        <span><h3><%= cr.description %></h3><h5>Request Expires: <%= cr.expires_date %></h5></span> 
+      <h2>Open Quotes</h2>
+      <% @open_quotes.each do |open_quote| %>
         <table class="table table-hover table-condensed">
           <thead>
             <tr>
+              <th>Request Description</th>
+              <th>Request Expires</th>
               <th>Company</th>
               <th>Start Date</th>
               <th>Completion Date Estimate</th>
@@ -15,25 +16,15 @@
             </tr>
           </thead>
           <tbody>
-            <% cr.open_quotes.each do |open_quote| %>
-            <% if open_quote.customer_viewed == false %>
-            <tr style="font-weight:bold;">
-              <td><%= open_quote.company.name %></td>
+            <tr>
+              <td><%= open_quote.customer_request.description %></td>
+              <td><%= open_quote.customer_request.expires_date %></td>
+              <td><%= open_quote.company.name%></td>
               <td><%= open_quote.start_date.strftime("%B %e, %Y") %></td>
               <td><%= open_quote.completion_date_estimate.strftime("%B %e, %Y") %></td>
               <td><%= number_to_currency(open_quote.total_cost_estimate) %></td>
               <td><a href="/quotes/<%= open_quote.id %>"><button class="btn btn-success">Details</button></a></td>
             </tr>
-            <% else %>
-             <tr>
-              <td><%= open_quote.company.name %></td>
-              <td><%= open_quote.start_date.strftime("%B %e, %Y") %></td>
-              <td><%= open_quote.completion_date_estimate.strftime("%B %e, %Y") %></td>
-              <td><%= number_to_currency(open_quote.total_cost_estimate) %></td>
-              <td><a href="/quotes/<%= open_quote.id %>"><button class="btn btn-success">Details</button></a></td>
-            </tr>
-            <% end %>
-            <% end %>
           </tbody>
         </table>
       <% end %>
@@ -46,9 +37,10 @@
     <h2>Accepted Quotes</h2>
       <% @accepted_quotes.each do |accepted_quote| %>
         <table class="table table-hover table-condensed">
-        <span><h3><%= accepted_quote.customer_request.description %></h3><h5>Request Expires: <%= accepted_quote.customer_request.expires_date %></h5></span> 
           <thead>
             <tr>
+              <th>Request Description</th>
+              <th>Request Expires</th>              
               <th>Company</th>
               <th>Start Date</th>
               <th>Completion Date Estimate</th>
@@ -58,6 +50,8 @@
           </thead>
           <tbody>
             <tr>
+              <td><%= accepted_quote.customer_request.description %></td>
+              <td><%= accepted_quote.customer_request.expires_date %></td>              
               <td><%= accepted_quote.company.name%></td>
               <td><%= accepted_quote.start_date.strftime("%B %e, %Y") %></td>
               <td><%= accepted_quote.completion_date_estimate.strftime("%B %e, %Y") %></td>

--- a/app/views/quotes/_customer_quotes.html.erb
+++ b/app/views/quotes/_customer_quotes.html.erb
@@ -2,7 +2,6 @@
   <div class="panel panel-default">
     <div class="panel-body">
       <h2>Open Quotes</h2>
-      <% @open_quotes.each do |open_quote| %>
         <table class="table table-hover table-condensed">
           <thead>
             <tr>
@@ -16,6 +15,7 @@
             </tr>
           </thead>
           <tbody>
+            <% @open_quotes.each do |open_quote| %>
             <tr>
               <td><%= open_quote.customer_request.description %></td>
               <td><%= open_quote.customer_request.expires_date %></td>
@@ -25,9 +25,9 @@
               <td><%= number_to_currency(open_quote.total_cost_estimate) %></td>
               <td><a href="/quotes/<%= open_quote.id %>"><button class="btn btn-success">Details</button></a></td>
             </tr>
+            <% end %>
           </tbody>
         </table>
-      <% end %>
     </div>
   </div>
 <% end %>
@@ -35,7 +35,6 @@
   <div class="panel panel-default">
     <div class="panel-body">
     <h2>Accepted Quotes</h2>
-      <% @accepted_quotes.each do |accepted_quote| %>
         <table class="table table-hover table-condensed">
           <thead>
             <tr>
@@ -49,6 +48,7 @@
             </tr>
           </thead>
           <tbody>
+            <% @accepted_quotes.each do |accepted_quote| %>
             <tr>
               <td><%= accepted_quote.customer_request.description %></td>
               <td><%= accepted_quote.customer_request.expires_date %></td>              
@@ -58,9 +58,9 @@
               <td><%= number_to_currency(accepted_quote.total_cost_estimate) %></td>
               <td><a href="/quotes/<%= accepted_quote.id %>"><button class="btn btn-success">Details</button></a></td>
             </tr>
+            <% end %>
           </tbody>
         </table>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/spec/controllers/contracts_controller_spec.rb
+++ b/spec/controllers/contracts_controller_spec.rb
@@ -156,14 +156,12 @@ RSpec.describe ContractsController, type: :controller do
           company_id: company_two.id,
           customer_request_id: customer_request.id
         )
-        # expect {
-          post :create, params: {
-            contract: {
-              quote_id: quote_one.id,
-              customer_request_id: customer_request.id
-            }
-         }
-        # }.to change{ quote_one.accepted }.to(true)
+        post :create, params: {
+          contract: {
+            quote_id: quote_one.id,
+            customer_request_id: customer_request.id
+          }
+        }
         expect(quote_one.reload.accepted).to eq(true)
         expect(quote_two.reload.accepted).to eq(false)
       end

--- a/spec/controllers/contracts_controller_spec.rb
+++ b/spec/controllers/contracts_controller_spec.rb
@@ -138,6 +138,37 @@ RSpec.describe ContractsController, type: :controller do
         }
       }.to change { ActionMailer::Base.deliveries.count }.by(3)
     end
+
+    describe 'quote status updated' do
+      it 'marks declined quotes as false and accepted quotes as true' do
+        company_one = create(:company)
+        company_two = create(:company)
+        customer = create(:customer)
+        sign_in customer
+        customer_request = create(:customer_request, customer_id: customer.id)
+        quote_one = create(
+          :quote,
+          company_id: company_one.id,
+          customer_request_id: customer_request.id
+        )
+        quote_two = create(
+          :quote,
+          company_id: company_two.id,
+          customer_request_id: customer_request.id
+        )
+        # expect {
+          post :create, params: {
+            contract: {
+              quote_id: quote_one.id,
+              customer_request_id: customer_request.id
+            }
+         }
+        # }.to change{ quote_one.accepted }.to(true)
+        expect(quote_one.reload.accepted).to eq(true)
+        expect(quote_two.reload.accepted).to eq(false)
+      end
+    end
+
   end
 
   describe 'GET #show' do

--- a/spec/controllers/quotes_controller_spec.rb
+++ b/spec/controllers/quotes_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe QuotesController, type: :controller do
         q2 = create(:quote, company_id: company1.id, accepted: true)
         q3 = create(:quote, company_id: company1.id, accepted: nil)
         get :index
-        expect(assigns(:open_quotes)).to eq([q1, q3])
+        expect(assigns(:open_quotes)).to match_array([q1, q3])
       end
     end
 

--- a/spec/controllers/quotes_controller_spec.rb
+++ b/spec/controllers/quotes_controller_spec.rb
@@ -20,27 +20,6 @@ RSpec.describe QuotesController, type: :controller do
   describe 'GET #index' do
     context 'with customer signed in' do
 
-      it 'only shows quotes that arent expired' do
-        customer = create(:customer)
-        sign_in customer
-        cr1 = create(:customer_request, customer_id: customer.id, expires_date: Date.today()-1)
-        cr2 = create(:customer_request, customer_id: customer.id, expires_date: Date.today()+1)
-        create(:quote, customer_request_id: cr1.id)
-        create(:quote, customer_request_id: cr2.id)
-        get :index
-        expect(assigns(:customer_requests)).to match_array [cr2]
-      end
-
-      it 'assigns the proper customer_requests to @customer_requests' do
-        customer = create(:customer)
-        sign_in customer
-        cr1 = create(:customer_request, customer_id: customer.id)
-        cr2 = create(:customer_request, customer_id: customer.id)
-        cr3 = create(:customer_request, customer_id: customer.id)
-        get :index
-        expect(assigns(:customer_requests)).to match_array [cr1, cr2, cr3]
-      end
-
       it 'assigns all the customers open quotes to @open_quotes' do
         company1 = create(:company)
         company2 = create(:company)

--- a/spec/controllers/quotes_controller_spec.rb
+++ b/spec/controllers/quotes_controller_spec.rb
@@ -19,17 +19,6 @@ require 'rails_helper'
 RSpec.describe QuotesController, type: :controller do
   describe 'GET #index' do
     context 'with customer signed in' do
-      context 'with request_id param' do
-        it 'assigns the proper customer_requests to @customer_requests' do
-          customer = create(:customer)
-          sign_in customer
-          cr1 = create(:customer_request, customer_id: customer.id)
-          create(:customer_request, customer_id: customer.id)
-          create(:customer_request, customer_id: customer.id)
-          get :index, params: { request_id: cr1.id }
-          expect(assigns(:customer_requests)).to match_array [cr1]
-        end
-      end
 
       it 'only shows quotes that arent expired' do
         customer = create(:customer)

--- a/spec/features/company_spec.rb
+++ b/spec/features/company_spec.rb
@@ -64,6 +64,75 @@ RSpec.describe 'company creates quote', :type => :feature do
   end
 end
 
+RSpec.describe "customer decides on quote", :type => :feature do
+  before :each do
+    @company1 = create :company, email: 'user1@example.com', password: 'password', status: 'Active', service_radius: 30.0, latitude: 41.9687556, longitude: -87.6939721
+    @company2 = create :company, email: 'user2@example.com', password: 'password', status: 'Active', service_radius: 30.0, latitude: 41.9687556, longitude: -87.6939721    
+    @service_category = create :service_category, name: 'Paint'
+    @customer = create :customer, email: 'customer@example.com', password: 'password'
+    @customer_request = create :customer_request, customer_id: @customer.id, description: 'Sample request description', service_category_id: @service_category.id, zipcode: '60601', expires_date: Date.today() + 3, latitude: 41.9687556, longitude: -87.6939721
+    @quote1 = create :quote, customer_request_id: @customer_request.id, company_id: @company1.id
+    @quote2 = create :quote, customer_request_id: @customer_request.id, company_id: @company2.id
+    visit '/companies/sign_in'
+    within(".login-form") do
+      fill_in 'company[email]', with: 'user1@example.com'
+      fill_in 'company[password]', with: 'password'
+    end
+    click_button 'Log in'
+  end
 
+  context 'company view of quotes table for open quotes' do
+    before :each do
+      visit('/quotes')
+    end
 
+    it 'should show open quotes in open quote table' do
+      within '#open_quotes' do
+        expect(page).to have_content('Sample request description')
+      end
+    end
+    it 'should not show open quotes in accepted quote table' do
+      within '#accepted_quotes' do
+        expect(page).to_not have_content('Sample request description')
+      end
+    end
+  end
 
+  context 'company view of quotes table when own quote is accepted' do
+    before :each do
+      @quote1.update(accepted: true)
+      @quote2.update(accepted: false)
+      visit('/quotes')
+    end
+
+    it 'should not show own accepted quotes in open quote table' do
+      within '#open_quotes' do
+        expect(page).to_not have_content('Sample request description')
+      end
+    end
+    it 'should show own accepted quotes in accepted quote table' do
+      within '#accepted_quotes' do
+        expect(page).to have_content('Sample request description')
+      end
+    end
+  end
+
+  context 'company view of quotes table when own quote is rejected' do
+    before :each do
+      @quote2.update(accepted: true)
+      @quote1.update(accepted: false)
+      visit('/quotes')
+    end
+
+    it 'should not show own rejected quotes in open quote table' do
+      within '#open_quotes' do
+        expect(page).to_not have_content('Sample request description')
+      end
+    end
+    it 'should not show own rejected quotes in accepted quote table' do
+      within '#accepted_quotes' do
+        expect(page).to_not have_content('Sample request description')
+      end
+    end
+  end
+end

--- a/spec/features/customer_spec.rb
+++ b/spec/features/customer_spec.rb
@@ -76,4 +76,41 @@ RSpec.describe "customer decides on quote", :type => :feature do
     first(:css, 'input.btn.btn-md.btn-success').click
     expect(page).to have_content 'Contract created and saved!'
   end
+
+  context 'customer view of quotes table for open quotes' do
+    before :each do
+      @customer_request.update(description: 'Sample request description')
+      visit('/quotes')
+    end
+
+    it 'should show open quotes in open quote table' do
+      within '#open_quotes' do
+        expect(page).to have_content('Sample request description')
+      end
+    end
+    it 'should not show open quotes in accepted quote table' do
+      within '#accepted_quotes' do
+        expect(page).to_not have_content('Sample request description')
+      end
+    end
+  end
+
+  context 'customer view of quotes table for accepted quotes' do
+    before :each do
+      @customer_request.update(description: 'Sample request description')
+      @quote.update(accepted: true)
+      visit('/quotes')
+    end
+
+    it 'should not show accepted quotes in open quote table' do
+      within '#open_quotes' do
+        expect(page).to_not have_content('Sample request description')
+      end
+    end
+    it 'should show accepted quotes in accepted quote table' do
+      within '#accepted_quotes' do
+        expect(page).to have_content('Sample request description')
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/QbsF7ngR/163-bug-once-a-quote-has-been-accepted-the-customer-request-still-shows-up-on-the-quotes-page

- Updated Quotes Show page to straight up show quotes (not divided by customer requests)
- Updated Contracts controller Create Action to rescue failed email & ensure Quote Accepted status is changed to False when contract is created with a competing quote
- Add tests to Contracts_controller_spec & features specs for company and customer